### PR TITLE
Update grid for horizontal expansion and grid snapping

### DIFF
--- a/script.js
+++ b/script.js
@@ -62,12 +62,21 @@ grid.querySelectorAll('.grid-item').forEach(item => {
 
   document.addEventListener('mousemove', (e) => {
     if (!isResizing) return;
+    // Only allow horizontal resizing
+    let grid = document.getElementById('grid');
+    let gridStyles = window.getComputedStyle(grid);
+    let columnGap = parseInt(gridStyles.gap || gridStyles.columnGap || '16', 10);
+    // Get the computed grid column width (assume all columns are same width)
+    let gridColumn = window.getComputedStyle(item);
+    // The grid uses minmax(150px, 1fr), so snap to multiples of 150px + gap
+    let minColWidth = 150;
     let newWidth = startWidth + (e.clientX - startX);
-    let newHeight = startHeight + (e.clientY - startY);
-    newWidth = Math.max(newWidth, 100);
-    newHeight = Math.max(newHeight, 100);
-    item.style.width = newWidth + 'px';
-    item.style.height = newHeight + 'px';
+    // Snap to nearest column size
+    let snappedCols = Math.round(newWidth / (minColWidth + columnGap));
+    snappedCols = Math.max(snappedCols, 1); // At least 1 column
+    let snappedWidth = snappedCols * minColWidth + (snappedCols - 1) * columnGap;
+    item.style.width = snappedWidth + 'px';
+    // Height remains fixed
   });
 
   document.addEventListener('mouseup', () => {

--- a/styles.css
+++ b/styles.css
@@ -10,9 +10,8 @@
   border: 2px solid #ccc;
   border-radius: 8px;
   min-width: 100px;
-  min-height: 100px;
+  height: 100px;
   max-width: 100%;
-  max-height: 100%;
   position: relative;
   padding: 16px;
   box-sizing: border-box;


### PR DESCRIPTION
Enable horizontal-only resizing for grid items with snapping to grid column widths.

---
<a href="https://cursor.com/background-agent?bcId=bc-d1e3d2f2-6a2b-4a26-a15d-2d02297c6181">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d1e3d2f2-6a2b-4a26-a15d-2d02297c6181">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>